### PR TITLE
set the Host on redirect

### DIFF
--- a/secureheader.go
+++ b/secureheader.go
@@ -98,6 +98,7 @@ func (c *Config) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if c.HTTPSRedirect && !c.isHTTPS(r) && !c.okloopback(r) {
 		url := *r.URL
 		url.Scheme = "https"
+		url.Host = r.Host
 		http.Redirect(w, r, url.String(), http.StatusMovedPermanently)
 		return
 	}


### PR DESCRIPTION
Fixes #7.

```
$ curl http://myapp-staging.herokuapp.com/ -i
HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=utf-8
Date: Thu, 24 Oct 2013 23:05:20 GMT
Location: https://myapp-staging.herokuapp.com/
Content-Length: 72
Connection: keep-alive

<a href="https://myapp-staging.herokuapp.com/">Moved Permanently</a>.
```
