### PR TITLE
add function Handler for convenience

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,27 +1,30 @@
 package secureheader_test
 
 import (
-	"github.com/kr/secureheader"
 	"net/http"
+
+	"github.com/kr/secureheader"
 )
 
 func Example() {
 	http.Handle("/", http.FileServer(http.Dir("/tmp")))
-	http.ListenAndServe(":80", secureheader.DefaultConfig)
+	http.ListenAndServe(":80", secureheader.Handler(nil))
 }
 
 func Example_custom() {
 	http.Handle("/", http.FileServer(http.Dir("/tmp")))
-	secureheader.DefaultConfig.HSTSIncludeSubdomains = false
-	secureheader.DefaultConfig.FrameOptions = false
-	http.ListenAndServe(":80", secureheader.DefaultConfig)
+	h := secureheader.Handler(http.DefaultServeMux)
+	h.HSTSIncludeSubdomains = false
+	h.FrameOptions = false
+	http.ListenAndServe(":80", h)
 }
 
 func Example_Content_Security_Policy() {
 	http.Handle("/", http.FileServer(http.Dir("/tmp")))
-	secureheader.DefaultConfig.CSP = true
-	secureheader.DefaultConfig.CSPBody = "default-src 'self' ; img-src 'self' data: ; style-src 'self'"
-	secureheader.DefaultConfig.CSPReportURI = "https://example.com/csp-reports"
-	http.ListenAndServe(":80", secureheader.DefaultConfig)
+	h := secureheader.Handler(http.DefaultServeMux)
+	h.CSP = true
+	h.CSPBody = "default-src 'self' ; img-src 'self' data: ; style-src 'self'"
+	h.CSPReportURI = "https://example.com/csp-reports"
+	http.ListenAndServe(":80", h)
 
 }

--- a/secureheader.go
+++ b/secureheader.go
@@ -58,6 +58,17 @@ var DefaultConfig = &Config{
 	XSSProtectionBlock: true,
 }
 
+// Handler returns a new HTTP handler
+// using the configuration in DefaultConfig,
+// serving requests using h.
+// If h is nil, it uses http.DefaultServeMux.
+func Handler(h http.Handler) *Config {
+	c := new(Config)
+	*c = *DefaultConfig
+	c.Next = h
+	return c
+}
+
 type Config struct {
 	// If true, redirects any request with scheme http to the
 	// equivalent https URL.


### PR DESCRIPTION
This function signature makes it easier to do the most
common usage patterns I'm aware of, after several years
of seeing this package used in the wild.

	http.Handle("/", secureheader.Handler(mux))
	http.ListenAndServe(addr, nil)

and

	http.Handle("/a", a)
	http.Handle("/b", b)
	http.ListenAndServe(addr, secureheader.Handler(nil))

and

	var h http.Handler
	h = mux
	h = middleware3(h)
	h = secureheader.Handler(h)
	h = middleware1(h)
	http.ListenAndServe(addr, h)